### PR TITLE
完了お題の保存時に UUID を使用して完了ページに即時反映されるように修正

### DIFF
--- a/src/actions/save-completed-topic.ts
+++ b/src/actions/save-completed-topic.ts
@@ -6,5 +6,5 @@ export async function saveCompletedTopicAction(
   text: string,
   completedAt: string,
 ) {
-  await saveCompletedTopic(text, completedAt);
+  return await saveCompletedTopic(text, completedAt);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,10 +23,7 @@ import {
   Input,
 } from "@/components/ui/";
 import { RefreshCw, CheckCircle } from "lucide-react";
-import {
-  fetchCompletedTopics,
-  deleteCompletedTopic,
-} from "@/lib/complete-topics";
+import { fetchCompletedTopics, unCompleteTopic } from "@/lib/complete-topics";
 import { saveCompletedTopicAction } from "@/actions/save-completed-topic";
 import { CompletedTopic, IndustryValue } from "@/types";
 import { motion, AnimatePresence } from "framer-motion";
@@ -105,20 +102,20 @@ export default function Home() {
     setDoneMap((prev) => ({ ...prev, [topic]: true }));
 
     const now = new Date().toISOString();
-    await saveCompletedTopicAction(topic, now);
+    const saved = await saveCompletedTopicAction(topic, now);
+
+    if (saved) {
+      setCompletedTopics((prev) => [saved, ...prev]);
+    }
 
     setTopics((prev) => prev.filter((t) => t !== topic));
-    setCompletedTopics((prev) => [
-      { id: topic, topic: topic, completedAt: now },
-      ...prev,
-    ]);
     setPreviousTopics((prev) => prev.filter((t) => t !== topic));
 
     setDoneMap((prev) => ({ ...prev, [topic]: false }));
   };
 
   const handleUnComplete = async (id: string) => {
-    await deleteCompletedTopic(id);
+    await unCompleteTopic(id);
     setCompletedTopics((prev) => prev.filter((t) => t.id !== id));
   };
 

--- a/src/lib/complete-topics.tsx
+++ b/src/lib/complete-topics.tsx
@@ -31,9 +31,9 @@ export async function saveCompletedTopic(topic: string, completedAt: string) {
 }
 
 /*
- * 完了したお題を削除（アーカイブ）
+ * 完了したお題を未完了に戻す
  */
-export async function deleteCompletedTopic(id: string) {
+export async function unCompleteTopic(id: string) {
   try {
     await notion.pages.update({
       page_id: id,


### PR DESCRIPTION
close #1 

- saveCompletedTopicAction が保存結果を返すように変更
- setCompletedTopics に正しい page ID を追加
- 未完了に戻す処理が正しく動作するよう修正